### PR TITLE
Provide styles props to CNRichTextEditor and CNToolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,12 @@ Actually we did not implement 'Toolbar buttons and menus' and 'Image Uploading P
 To see an example of how to implement more advanced feature of this editor please check this [Link](https://github.com/imnapo/react-native-cn-richtext-editor/blob/master/expo-demo/App.js).
 
 Also be noticed that this example is writen with expo and required 'react-native-popup-menu' package.
-## Props
+
+## API
 
 ### CNRichTextEditor
+
+#### Props
 
 | Name | Description | Required |
 | ------ | ----------- | ---- |
@@ -180,8 +183,20 @@ Also be noticed that this example is writen with expo and required 'react-native
 | value    | an array object which keeps value of the editor | Yes |
 | styleList  | an object consist of styles name and values (use getDefaultStyles function) | Yes |
 | ImageComponent | a React component (class or functional) which will be used to render images. Will be passed `style` and `source` props. | No |
+| style | Styles applied to the outermost component. | No |
+| contentContainerStyle | Styles applied to the scrollview content. | No |
+
+#### Instance methods
+
+| Name | Params | Description |
+| ------ | ---- | ----------- |
+| applyToolbar | `toolType` | Apply the given transformation to selected text. |
+| insertImage | `uri, id?, height?, width?` | Insert the provided image where cursor is positionned. |
+| focus |  | Focus to the last `TextInput` |
 
 ### CNToolbar
+
+#### Props
 
 | Name | Required | Description |
 | ------ | ------ | ----------- |
@@ -200,9 +215,15 @@ Also be noticed that this example is writen with expo and required 'react-native
 | image  | No  | a component which renders as image button |
 | highlight  | No  | a component which renders as highlight button |
 | foreColor  | No  | a component which renders as foreColor button |
-
+| style | No | style applied to container |
+| color | No | default color passed to icon |
+| backgroundColor | No | default background color passed to icon |
+| selectedColor | No | color applied when icon is selected |
+| selectedBackgroundColor | No | background color applied when icon is selected |
+| iconContainerStyle | No | a style prop assigned to icon container |
 
 ### Functions
+
 | Name | Param | Returns | Description |
 | ------ | ------ | ------ |----------- |
 | getInitialObject | - | javascript object  | create a initial value for the editor. |
@@ -211,6 +232,7 @@ Also be noticed that this example is writen with expo and required 'react-native
 | getDefaultStyles | - | javascript object  | creates required styles for the editor. |
 
 ## Expo Demo App
+
 Checkout the
 [expo-demo App](https://expo.io/@imnapo/expo-demo)
 on Expo which uses react-native-cn-richtext-editor components.
@@ -219,5 +241,5 @@ If you are looking to test and run expo-demo App locally, click
 view the implementation & run it locally.
 
 ## License
-ISC
 
+ISC

--- a/src/CNRichTextEditor.js
+++ b/src/CNRichTextEditor.js
@@ -528,7 +528,7 @@ class CNRichTextEditor extends Component {
 
     render() {
 
-        const {value, style} = this.props;
+        const {value, style, contentContainerStyle} = this.props;
         
         return (      
                 <View
@@ -538,11 +538,11 @@ class CNRichTextEditor extends Component {
                 }, style]}>
 
                 
-                <ScrollView contentContainerStyle={{
+                <ScrollView contentContainerStyle={[{
                     flexGrow: 1,
                     alignContent: 'flex-start',
                     justifyContent: 'flex-start',
-                }} >
+                }, contentContainerStyle]} >
                     <View style={{
                          flex: 1,
                          alignContent: 'flex-start',

--- a/src/CNToolbar.js
+++ b/src/CNToolbar.js
@@ -19,10 +19,11 @@ class CNToolbar extends Component {
     }
 
     renderStyleButtons(size, color, bgColor, selectedColor, selectedBgColor) {
-        const { selectedStyles, selectedTag, bold,
+        const { selectedStyles, selectedTag, bold, iconContainerStyle,
             italic,
             underline,
             lineThrough } = this.props;
+        const iconStyles = [styles.iconContainer, iconContainerStyle]
         return (
             <View style={[styles.iconSetContainer, { flexGrow: 4 }]}>
                 {
@@ -31,8 +32,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('bold');
                             }}>
-                            <View style={[styles.iconContainer
-                                , {
+                            <View style={[iconStyles, {
                                 backgroundColor: selectedStyles.indexOf('bold') >= 0 ? selectedBgColor : bgColor
                             }]}>
                                 {
@@ -49,7 +49,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('italic');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedStyles.indexOf('italic') >= 0 ? selectedBgColor : bgColor
                             }]}>
@@ -66,7 +66,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('underline');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedStyles.indexOf('underline') >= 0 ? selectedBgColor : bgColor
                             }]}>
@@ -83,7 +83,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('lineThrough');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedStyles.indexOf('lineThrough') >= 0 ? selectedBgColor : bgColor
                             }]}>
@@ -100,10 +100,12 @@ class CNToolbar extends Component {
 
     renderTagButtons(size, color, bgColor, selectedColor, selectedBgColor) {
         const { selectedStyles, selectedTag, title,
-            heading,
+            heading, iconContainerStyle,
             ul,
             ol,
             body, } = this.props;
+        const iconStyles = [styles.iconContainer, iconContainerStyle]
+
         return (
             <View style={[styles.iconSetContainer, { flexGrow: 5 }]}>
                 {body ?
@@ -111,7 +113,7 @@ class CNToolbar extends Component {
                         onPress={() => {
                             this.onStyleKeyPress('body');
                         }}>
-                        <View style={[styles.iconContainer
+                        <View style={[iconStyles
                             , {
                             backgroundColor: selectedTag === 'body' ? selectedBgColor : bgColor
                         }]}>
@@ -129,7 +131,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('title');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedTag === 'title' ? selectedBgColor : bgColor
                             }]}>
@@ -146,7 +148,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('heading');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedTag === 'heading' ? selectedBgColor : bgColor
                             }]}>
@@ -163,7 +165,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('ul');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedTag === 'ul' ? selectedBgColor : bgColor
                             }]}>
@@ -180,7 +182,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('ol');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedTag === 'ol' ? selectedBgColor : bgColor
                             }]}>
@@ -197,10 +199,11 @@ class CNToolbar extends Component {
 
     renderExtras(size, color, bgColor, selectedColor, selectedBgColor) {
         const { selectedStyles, selectedTag, title,
-            image,
+            image, iconContainerStyle,
             highlight,
             foreColor,
         } = this.props;
+        const iconStyles = [styles.iconContainer, iconContainerStyle]
         return (
             <View style={[styles.iconSetContainer, { flexGrow: 2 }]}>
                 {
@@ -210,7 +213,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('image');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: bgColor
                             }]}>
@@ -227,7 +230,7 @@ class CNToolbar extends Component {
                             onPress={() => {
                                 this.onStyleKeyPress('foreColor');
                             }}>
-                            <View style={[styles.iconContainer
+                            <View style={[iconStyles
                                 , {
                                 backgroundColor: selectedStyles.indexOf('foreColor') >= 0 ? selectedBgColor : bgColor
                             }]}>
@@ -243,7 +246,7 @@ class CNToolbar extends Component {
                         onPress={() => {
                             this.onStyleKeyPress('highlight');
                         }}>
-                        <View style={[styles.iconContainer
+                        <View style={[iconStyles
                             , {
                             backgroundColor: selectedStyles.indexOf('highlight') >= 0 ? selectedBgColor : bgColor
                         }]}>
@@ -263,7 +266,7 @@ class CNToolbar extends Component {
         const { selectedStyles, selectedTag,
             bold, italic, underline, lineThrough,
             title, heading, ul, ol, body,
-            image, foreColor, highlight
+            image, foreColor, highlight, style
         } = this.props;
 
         let styleButtons = !bold && !italic && !underline && !lineThrough;
@@ -277,7 +280,7 @@ class CNToolbar extends Component {
         let selectedBgColor = this.props.selectedBackgroundColor ? this.props.selectedBackgroundColor : defaultSelectedBgColor;
 
         return (
-            <View style={styles.toolbarContainer}>
+            <View style={[styles.toolbarContainer, style]}>
                 {styleButtons === false ? this.renderStyleButtons(size, color, bgColor, selectedColor, selectedBgColor) : null}
                 {(styleButtons === false && tagButtons === false) ? <View style={styles.separator}></View> : null}
                 {tagButtons === false ? this.renderTagButtons(size, color, bgColor, selectedColor, selectedBgColor) : null}


### PR DESCRIPTION
A few props I needed to customize the styling! Glad to share.
Here is a summary of those changes:

- add support for CNRichTextEditor contentContainerStyle prop
- add support for CNToolbar style prop
- add support for CNToolbar iconContainerStyle prop
- document those new props in README
- describe instance methods in README
- describe missing CNToollbar color-related props in README

![Screenshot_20190320_150436](https://user-images.githubusercontent.com/3646758/54698575-d1fbd880-4b2f-11e9-9fce-2cc114d995a2.png)

