### PR TITLE
update to reflect material icon name change

### DIFF
--- a/expo-demo/App.js
+++ b/expo-demo/App.js
@@ -334,7 +334,7 @@ class App extends Component {
                         title={<MaterialCommunityIcons name="format-header-1" />}
                         heading={<MaterialCommunityIcons name="format-header-3" />}
                         ul={<MaterialCommunityIcons name="format-list-bulleted" />}
-                        ol={<MaterialCommunityIcons name="format-list-numbers" />}
+                        ol={<MaterialCommunityIcons name="format-list-numbered" />}
                         image={this.renderImageSelector()}
                         foreColor={this.renderColorSelector()}
                         highlight={this.renderHighlight()}


### PR DESCRIPTION
In https://github.com/oblador/react-native-vector-icons/commit/552e65503a0fa1f81406e0ce83b5bd3c4cceabb6, it looks like `format-list-numbers` was renamed to `format-list-numbered`, which was causing a warning in the demo: 

<img width="447" alt="image" src="https://user-images.githubusercontent.com/1245284/60621047-b5b43c80-9daa-11e9-94ec-2c2bb599e15d.png">
