### PR TITLE
fix: fix optional ts types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export interface CNRichTextEditorProps {
   onFocus?: () => void;
   onBlur?: () => void;
   placeholder: string;
-  textInputStyle: StyleProp<TextStyle>;
+  textInputStyle?: StyleProp<TextStyle>;
 }
 
 export default class CNRichTextEditor extends Component<CNRichTextEditorProps> {


### PR DESCRIPTION
`textInputStyle` is not required

This PR fixes the wrong type warning.